### PR TITLE
Add extra parameters to gce-github-runner

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -42,6 +42,13 @@ maintenance_policy_terminate=
 arm=
 accelerator=
 min_cpu_platform_flag=
+create_disk=
+enable_nested_virtualization=
+metadata=
+network_interface=
+provisioning_model=
+reservation_affinity=
+
 
 OPTLIND=1
 while getopts_long :h opt \
@@ -71,6 +78,12 @@ while getopts_long :h opt \
   maintenance_policy_terminate optional_argument \
   accelerator optional_argument \
   min_cpu_platform optional_argument \
+  create_disk optional_argument \
+  enable_nested_virtualization required_argument \
+  metadata optional_argument \
+  network_interface optional_argument \
+  provisioning_model optional_argument \
+  reservation_affinity optional_argument \
   help no_argument "" "$@"
 do
   case "$opt" in
@@ -152,6 +165,24 @@ do
     min_cpu_platform)
       min_cpu_platform_flag=--min-cpu-platform="$OPTLARG"
       ;;
+    create_disk)
+      create_disk=$OPTLARG
+      ;;
+    enable_nested_virtualization)
+      enable_nested_virtualization=$OPTLARG
+      ;;
+    metadata)
+      metadata=$OPTLARG
+      ;;
+    network_interface)
+      network_interface=$OPTLARG
+      ;;
+    provisioning_model)
+      provisioning_model=$OPTLARG
+      ;;
+    reservation_affinity)
+      reservation_affinity=$OPTLARG
+      ;;
     h|help)
       usage
       exit 0
@@ -166,7 +197,7 @@ done
 
 function gcloud_auth {
   # NOTE: when --project is specified, it updates the config
-  echo ${service_account_key} | gcloud --project  ${project_id} --quiet auth activate-service-account --key-file - &>/dev/null
+  echo ${service_account_key} | gcloud --project  ${project_id} --quiet auth activate-service-account ${runner_service_account} --key-file - &>/dev/null
   echo "✅ Successfully configured gcloud."
 }
 
@@ -185,7 +216,7 @@ function start_vm {
       jq -r .token)
   echo "✅ Successfully got the GitHub Runner registration token"
 
-  VM_ID="${vm_name_prefix}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+  VM_ID="${vm_name_prefix//./-}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
   service_account_flag=$([[ -z "${runner_service_account}" ]] || echo "--service-account=${runner_service_account}")
   image_project_flag=$([[ -z "${image_project}" ]] || echo "--image-project=${image_project}")
   image_flag=$([[ -z "${image}" ]] || echo "--image=${image}")
@@ -199,6 +230,12 @@ function start_vm {
   subnet_flag=$([[ ! -z "${subnet}"  ]] && echo "--subnet=${subnet}" || echo "")
   accelerator=$([[ ! -z "${accelerator}"  ]] && echo "--accelerator=${accelerator} --maintenance-policy=TERMINATE" || echo "")
   maintenance_policy_flag=$([[ -z "${maintenance_policy_terminate}"  ]] || echo "--maintenance-policy=TERMINATE" )
+  create_disk_flag=$([[ ! -z "${create_disk}"  ]] && echo "--create-disk=${create_disk}" || echo "")
+  enable_nested_virtualization_flag=$([[ "${enable_nested_virtualization}" == "true" ]] && echo "--enable-nested-virtualization" || echo "--no-enable-nested-virtualization")
+  metadata_flag=$([[ ! -z "${metadata}"  ]] && echo "${metadata}" || echo "")
+  network_interface_flag=$([[ ! -z "${network_interface}"  ]] && echo "--network-interface=${network_interface}" || echo "")
+  provisioning_model_flag=$([[ ! -z "${provisioning_model}"  ]] && echo "--provisioning-model=${provisioning_model}" || echo "")
+  reservation_affinity_flag=$([[ ! -z "${reservation_affinity}"  ]] && echo "--reservation-affinity=${reservation_affinity}" || echo "")
 
   echo "The new GCE VM will be ${VM_ID}"
 
@@ -314,6 +351,7 @@ function start_vm {
 
   gcloud compute instances create ${VM_ID} \
     --zone=${machine_zone} \
+    ${create_disk_flag} \
     ${disk_size_flag} \
     ${boot_disk_type_flag} \
     --machine-type=${machine_type} \
@@ -329,13 +367,18 @@ function start_vm {
     ${accelerator} \
     ${maintenance_policy_flag} \
     "${min_cpu_platform_flag}" \
+    ${enable_nested_virtualization_flag} \
     --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}" \
-    --metadata=startup-script="$startup_script" \
+    --metadata=startup-script="$startup_script",${metadata_flag} \
+    ${network_interface_flag} \
+    ${provisioning_model_flag} \
+    ${reservation_affinity_flag} \
     && echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off
   while (( i++ < 60 )); do
     GH_READY=$(gcloud compute instances describe ${VM_ID} --zone=${machine_zone} --format='json(labels)' | jq -r .labels.gh_ready)
+    echo "GH_READY: $GH_READY"
     if [[ $GH_READY == 1 ]]; then
       break
     fi

--- a/action.yml
+++ b/action.yml
@@ -107,6 +107,33 @@ inputs:
     description: "When specified, the VM will be scheduled on host with specified CPU architecture or a newer one."
     default: AUTOMATIC
     required: true
+  create_disk:
+    description: Creates and attaches persistent disks to the instances; https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--[no-]enable-nested-virtualization
+    required: false
+  enable_nested_virtualization:
+    description: Enables nested virtualization on the instance.
+    default: false
+    required: true
+  metadata:
+    description: >
+      Metadata to be made available to the guest operating system running on the instances.
+      Should be a comma-separated list of key=value pairs.
+    required: false
+  network_interface:
+    description: Adds a network interface to the instance. Mutually exclusive with network flag.
+    required: false
+  provisioning_model:
+    description: Specifies the provisioning model for your VM instances.
+    default: STANDARD
+    required: true
+  reservation_affinity:
+    description: The type of reservation for the instance.
+    default: any
+    required: true
+  exa_next_version_core:
+    description: EXA Next Version Core
+    required: false
+
 outputs:
   label:
     description: >-
@@ -124,7 +151,7 @@ runs:
         --project_id=${{ inputs.project_id }}
         --service_account_key='${{ inputs.service_account_key }}'
         --runner_ver=${{ inputs.runner_ver }}
-        --vm_name_prefix=${{ inputs.vm_name_prefix }}
+        --vm_name_prefix=${{ inputs.vm_name_prefix }}-${{ inputs.exa_next_version_core }}
         --machine_zone=${{ inputs.machine_zone }}
         --machine_type=${{ inputs.machine_type }}
         --network=${{ inputs.network }}
@@ -145,4 +172,10 @@ runs:
         --maintenance_policy_terminate=${{ inputs.maintenance_policy_terminate }}
         --arm=${{ inputs.arm }}
         --min_cpu_platform='${{ inputs.min_cpu_platform }}'
+        --create_disk='${{ inputs.create_disk }}'
+        --enable_nested_virtualization=${{ inputs.enable_nested_virtualization }}
+        --metadata='${{ inputs.metadata }}'
+        --network_interface='${{ inputs.network_interface }}'
+        --provisioning_model='${{ inputs.provisioning_model }}'
+        --reservation_affinity='${{ inputs.reservation_affinity }}'
       shell: bash


### PR DESCRIPTION
Added the following new parameters:
- [create-disk](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk)
- [enable-nested-virtualization](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--[no-]enable-nested-virtualization)
- [metadata](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--metadata)
- [network-interface](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--network-interface)
- [provisioning-model](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--provisioning-model)
- [reservation-affinity](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--reservation-affinity)